### PR TITLE
Add build-arg to control release version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,11 @@
 FROM alpine
 MAINTAINER Christian Gatzlaff <cgatzlaff@gmail.com>
 
+ARG PHP_VIRTUAL_BOX_RELEASE=5.2-1
+
 RUN apk update && apk add --no-cache bash nginx php7-fpm php7-cli php7-common php7-json php7-soap php7-simplexml php7-session \
     && apk add --no-cache --virtual build-dependencies wget unzip \
-    && wget --no-check-certificate https://github.com/phpvirtualbox/phpvirtualbox/archive/5.2-1.zip -O phpvirtualbox.zip \
+    && wget --no-check-certificate https://github.com/phpvirtualbox/phpvirtualbox/archive/${PHP_VIRTUAL_BOX_RELEASE}.zip -O phpvirtualbox.zip \
     && unzip phpvirtualbox.zip -d phpvirtualbox \
     && mkdir -p /var/www \
     && mv -v phpvirtualbox/*/* /var/www/ \


### PR DESCRIPTION
Since the official phpVirtualBox project has not created a new release in two years, the current build of this project is incompatible with VirtualBox 6.1. Adding a build-arg makes it easy to build against a different target version of the upstream package (such as the `develop` branch, as is described [here](https://github.com/jazzdd86/phpVirtualbox/issues/16#issuecomment-632024127)).